### PR TITLE
feat: Add /send_text command for sending SMS via Twilio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ DISCORD_GUILD_ID=your_real_discord_guild_id
 OPENAI_API_KEY=your_real_openai_api_key
 OPENAI_ASSISTANT_ID=your_assistant_id_here
 
+# Twilio Configuration
+TWILIO_ACCOUNT_SID=your_twilio_account_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+TWILIO_PHONE_NUMBER=your_twilio_phone_number
+
 # Weather API Configuration
 OPENWEATHER_API_KEY=your_actual_api_key_here
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express-rate-limit": "^7.1.5",
         "node-cache": "^5.1.2",
         "openai": "^4.77.4",
+        "twilio": "^5.7.0",
         "winston": "^3.11.0",
         "xml2js": "^0.6.2"
       },
@@ -1574,6 +1575,17 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -1712,10 +1724,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1946,6 +1957,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1968,7 +1984,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1982,7 +1997,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2316,6 +2330,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2466,7 +2485,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2474,6 +2492,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2548,7 +2574,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2558,7 +2583,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2568,7 +2592,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3185,7 +3208,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -3220,7 +3242,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -3298,7 +3319,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3335,7 +3355,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3377,6 +3396,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -4381,6 +4412,57 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4460,12 +4542,47 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -4550,7 +4667,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4824,7 +4940,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5279,7 +5394,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -5556,6 +5670,11 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
     },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5663,7 +5782,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -5683,7 +5801,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -5700,7 +5817,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5719,7 +5835,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6067,6 +6182,31 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/twilio": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.7.0.tgz",
+      "integrity": "sha512-AcN9jo/C0sFitprIg2G6CJF+EACvff+8fiTMxf7Puz+6jtmc0NgJTwmyQbPiAnJcpXWOrPdI92Obr3PV4ZKXkw==",
+      "dependencies": {
+        "axios": "^1.8.3",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.2",
+        "qs": "^6.9.4",
+        "scmp": "^2.1.0",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/twilio/node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express-rate-limit": "^7.1.5",
     "node-cache": "^5.1.2",
     "openai": "^4.77.4",
+    "twilio": "^5.7.0",
     "winston": "^3.11.0",
     "xml2js": "^0.6.2"
   },

--- a/src/commands/__tests__/send_text.test.js
+++ b/src/commands/__tests__/send_text.test.js
@@ -1,0 +1,129 @@
+const sendTextCommand = require('../send_text');
+const twilioService = require('../../services/twilio');
+const logger = new require('../../utils/logger'); // Actual logger for spy
+
+// Mock the twilioService
+jest.mock('../../services/twilio', () => ({
+  sendTextMessage: jest.fn(),
+  isConfigured: jest.fn(),
+}));
+
+// Mock logger (actual logger for spy, mock others if necessary)
+jest.mock('../../utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+// Mock handleInteractionError if it's used and you want to assert its call
+jest.mock('../../utils/errors', () => ({
+    handleInteractionError: jest.fn(),
+}));
+
+
+describe('/send_text Command', () => {
+  let mockInteraction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInteraction = {
+      options: {
+        getString: jest.fn(),
+      },
+      reply: jest.fn().mockResolvedValue(true),
+      editReply: jest.fn().mockResolvedValue(true),
+      deferReply: jest.fn().mockResolvedValue(true),
+      user: {
+        tag: 'testuser#1234',
+      },
+      replied: false,
+      deferred: false,
+    };
+  });
+
+  it('should reply that service is not configured if twilioService.isConfigured() is false', async () => {
+    twilioService.isConfigured.mockReturnValue(false);
+
+    await sendTextCommand.execute(mockInteraction);
+
+    expect(twilioService.isConfigured).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.reply).toHaveBeenCalledWith({
+      content: 'The SMS service is not configured. Please contact the bot administrator.',
+      ephemeral: true,
+    });
+    expect(twilioService.sendTextMessage).not.toHaveBeenCalled();
+  });
+
+  it('should reply with invalid phone number format if format is incorrect', async () => {
+    twilioService.isConfigured.mockReturnValue(true);
+    mockInteraction.options.getString.mockImplementation(optionName => {
+      if (optionName === 'phone_number') return '12345'; // Invalid format
+      if (optionName === 'message') return 'Test message';
+      return null;
+    });
+
+    await sendTextCommand.execute(mockInteraction);
+
+    expect(mockInteraction.reply).toHaveBeenCalledWith({
+      content: 'Invalid phone number format. Please use E.164 format (e.g., +12345678900).',
+      ephemeral: true,
+    });
+    expect(twilioService.sendTextMessage).not.toHaveBeenCalled();
+  });
+
+  it('should call twilioService.sendTextMessage and reply with success on valid input', async () => {
+    twilioService.isConfigured.mockReturnValue(true);
+    const testPhoneNumber = '+12345678900';
+    const testMessage = 'This is a test message';
+    mockInteraction.options.getString.mockImplementation(optionName => {
+      if (optionName === 'phone_number') return testPhoneNumber;
+      if (optionName === 'message') return testMessage;
+      return null;
+    });
+    twilioService.sendTextMessage.mockResolvedValue({ sid: 'SMxxxxxxxxxxxx' });
+
+    await sendTextCommand.execute(mockInteraction);
+
+    expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(twilioService.sendTextMessage).toHaveBeenCalledWith(testPhoneNumber, testMessage);
+    expect(mockInteraction.editReply).toHaveBeenCalledWith({
+      content: `Message sent successfully to ${testPhoneNumber}!`,
+    });
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining(`Successfully sent SMS via /send_text command to ${testPhoneNumber}`));
+  });
+
+  it('should handle errors from twilioService.sendTextMessage and reply with failure', async () => {
+    twilioService.isConfigured.mockReturnValue(true);
+    const testPhoneNumber = '+12345678900';
+    const testMessage = 'This is a test message';
+    mockInteraction.options.getString.mockImplementation(optionName => {
+      if (optionName === 'phone_number') return testPhoneNumber;
+      if (optionName === 'message') return testMessage;
+      return null;
+    });
+    const errorMessage = 'Twilio API is down';
+    twilioService.sendTextMessage.mockRejectedValue(new Error(errorMessage));
+
+    await sendTextCommand.execute(mockInteraction);
+
+    expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(twilioService.sendTextMessage).toHaveBeenCalledWith(testPhoneNumber, testMessage);
+    expect(mockInteraction.editReply).toHaveBeenCalledWith({
+      content: `Failed to send message: ${errorMessage}`,
+    });
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to send SMS via /send_text command'), expect.any(Error));
+  });
+
+  it('should handle generic errors during execution', async () => {
+    twilioService.isConfigured.mockReturnValue(true);
+    mockInteraction.options.getString.mockImplementation(() => { throw new Error('Unexpected option error'); });
+
+    await sendTextCommand.execute(mockInteraction);
+
+    expect(logger.error).toHaveBeenCalledWith('Error in send_text command execution:', expect.any(Error));
+    // Depending on when the error happens, either reply or editReply would be called
+    // For this specific mock, deferReply won't be called.
+    expect(mockInteraction.reply).toHaveBeenCalledWith({ content: 'An error occurred while processing your request.', ephemeral: true });
+  });
+});

--- a/src/commands/send_text.js
+++ b/src/commands/send_text.js
@@ -1,0 +1,72 @@
+const { SlashCommandBuilder } = require('discord.js');
+const twilioService = require('../services/twilio');
+const logger = require('../utils/logger');
+const { handleInteractionError } = require('../utils/errors'); // Assuming you have this error handler
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('send_text')
+    .setDescription('Sends a text message to a specified phone number.')
+    .addStringOption(option =>
+      option.setName('phone_number')
+        .setDescription('The phone number to send the message to (e.g., +12345678900)')
+        .setRequired(true))
+    .addStringOption(option =>
+      option.setName('message')
+        .setDescription('The content of the message to send.')
+        .setRequired(true)),
+
+  async execute(interaction) {
+    try {
+      if (!twilioService.isConfigured()) {
+        await interaction.reply({
+          content: 'The SMS service is not configured. Please contact the bot administrator.',
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const phoneNumber = interaction.options.getString('phone_number');
+      const messageContent = interaction.options.getString('message');
+
+      // Basic validation for phone number format (E.164)
+      // More robust validation should ideally be in the Twilio service or a dedicated utility
+      if (!/^\+[1-9]\d{1,14}$/.test(phoneNumber)) {
+        await interaction.reply({
+          content: 'Invalid phone number format. Please use E.164 format (e.g., +12345678900).',
+          ephemeral: true,
+        });
+        return;
+      }
+
+      // Defer reply as sending SMS can take time
+      await interaction.deferReply({ ephemeral: true });
+
+      try {
+        await twilioService.sendTextMessage(phoneNumber, messageContent);
+        await interaction.editReply({
+          content: `Message sent successfully to ${phoneNumber}!`,
+        });
+        logger.info(`Successfully sent SMS via /send_text command to ${phoneNumber} by user ${interaction.user.tag}`);
+      } catch (error) {
+        logger.error(`Failed to send SMS via /send_text command for user ${interaction.user.tag}:`, error);
+        await interaction.editReply({
+          content: `Failed to send message: ${error.message || 'An unexpected error occurred.'}`,
+        });
+      }
+
+    } catch (error) {
+      // This catch is for errors during initial interaction handling (e.g., deferReply)
+      // or if handleInteractionError is not used for the Twilio call.
+      logger.error('Error in send_text command execution:', error);
+      // Use handleInteractionError or a direct reply if it's not already handled
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({ content: 'An error occurred while processing your request.', ephemeral: true });
+      } else if (interaction.deferred && !interaction.replied) {
+        await interaction.editReply({ content: 'An error occurred while processing your request.'});
+      }
+      // If you have a generic error handler like handleInteractionError, you might call it here:
+      // await handleInteractionError(error, interaction);
+    }
+  },
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,6 +24,11 @@ const config = {
     geoEndpoint: 'http://api.openweathermap.org/geo/1.0/direct',
     weatherEndpoint: 'https://api.open-meteo.com/v1/forecast'
   },
+  twilio: {
+    accountSid: process.env.TWILIO_ACCOUNT_SID,
+    authToken: process.env.TWILIO_AUTH_TOKEN,
+    phoneNumber: process.env.TWILIO_PHONE_NUMBER
+  },
   rateLimiting: {
     windowMs: 60000, // 1 minute
     maxRequests: 5

--- a/src/services/__tests__/twilio.test.js
+++ b/src/services/__tests__/twilio.test.js
@@ -1,0 +1,163 @@
+const twilioService = require('../twilio');
+const config = require('../../config');
+const logger = require('../../utils/logger');
+
+// Mock the Twilio library
+jest.mock('twilio', () => {
+  const mockMessagesCreate = jest.fn();
+  return jest.fn(() => ({
+    messages: {
+      create: mockMessagesCreate,
+    },
+  }));
+});
+
+// Mock logger to prevent console output during tests
+jest.mock('../../utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+// Hold a reference to the mock function
+let mockTwilioMessagesCreate;
+beforeEach(() => {
+  // Reset mocks before each test
+  jest.clearAllMocks();
+  // Get the fresh mock function instance
+  const twilio = require('twilio');
+  mockTwilioMessagesCreate = twilio().messages.create;
+});
+
+describe('Twilio Service', () => {
+  describe('sendTextMessage', () => {
+    const originalTwilioConfig = { ...config.twilio };
+
+    beforeEach(() => {
+      // Ensure a clean config state for Twilio
+      config.twilio = { ...originalTwilioConfig };
+       // Re-initialize the service to pick up the potentially changed config
+       jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+    });
+
+    afterAll(() => {
+      // Restore original config
+      config.twilio = originalTwilioConfig;
+    });
+
+    it('should send a message successfully if configured', async () => {
+      config.twilio.accountSid = 'ACxxxxxxxxxxxxxxx';
+      config.twilio.authToken = 'authxxxxxxxxxxxxx';
+      config.twilio.phoneNumber = '+1234567890';
+
+      // Re-require the module to re-initialize the client with new config
+      jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+
+      mockTwilioMessagesCreate.mockResolvedValue({ sid: 'SMxxxxxxxxxxxxxxx' });
+
+      const to = '+19876543210';
+      const body = 'Test message';
+      await twilioService.sendTextMessage(to, body);
+
+      expect(mockTwilioMessagesCreate).toHaveBeenCalledWith({
+        body: body,
+        from: config.twilio.phoneNumber,
+        to: to,
+      });
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('SMS sent successfully'));
+    });
+
+    it('should throw an error if Twilio is not configured', async () => {
+      config.twilio.accountSid = ''; // Simulate not configured
+       // Re-require the module to re-initialize the client with new config
+      jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+
+      await expect(twilioService.sendTextMessage('+19876543210', 'Test'))
+        .rejects.toThrow('Twilio service is not configured.');
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Twilio client is not initialized'));
+    });
+
+    it('should throw an error if "to" or "body" is missing', async () => {
+      config.twilio.accountSid = 'ACxxxxxxxxxxxxxxx'; // Configured
+      config.twilio.authToken = 'authxxxxxxxxxxxxx';
+      config.twilio.phoneNumber = '+1234567890';
+       // Re-require the module to re-initialize the client with new config
+      jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+
+      await expect(twilioService.sendTextMessage(null, 'Test'))
+        .rejects.toThrow('Recipient phone number (to) and message body are required.');
+      await expect(twilioService.sendTextMessage('+19876543210', null))
+        .rejects.toThrow('Recipient phone number (to) and message body are required.');
+    });
+
+    it('should log a warning for invalid phone number format but attempt to send', async () => {
+      config.twilio.accountSid = 'ACxxxxxxxxxxxxxxx';
+      config.twilio.authToken = 'authxxxxxxxxxxxxx';
+      config.twilio.phoneNumber = '+1234567890';
+      jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+      mockTwilioMessagesCreate.mockResolvedValue({ sid: 'SMxxxxxxxxxxxxxxx' });
+
+      const invalidPhoneNumber = '12345';
+      await twilioService.sendTextMessage(invalidPhoneNumber, 'Test message');
+
+      expect(logger.warn).toHaveBeenCalledWith(`Invalid phone number format: ${invalidPhoneNumber}. Attempting to send anyway.`);
+      expect(mockTwilioMessagesCreate).toHaveBeenCalled();
+    });
+
+    it('should throw an error if Twilio API call fails', async () => {
+      config.twilio.accountSid = 'ACxxxxxxxxxxxxxxx';
+      config.twilio.authToken = 'authxxxxxxxxxxxxx';
+      config.twilio.phoneNumber = '+1234567890';
+      jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+
+      const errorMessage = 'Twilio API Error';
+      mockTwilioMessagesCreate.mockRejectedValue(new Error(errorMessage));
+
+      await expect(twilioService.sendTextMessage('+19876543210', 'Test'))
+        .rejects.toThrow(`Failed to send SMS via Twilio: ${errorMessage}`);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error sending SMS'), expect.any(Error));
+    });
+  });
+
+  describe('isConfigured', () => {
+    // Similar setup for config and re-requiring module as above
+    const originalTwilioConfig = { ...config.twilio };
+     beforeEach(() => {
+      config.twilio = { ...originalTwilioConfig };
+    });
+    afterAll(() => {
+      config.twilio = originalTwilioConfig;
+    });
+
+    it('should return true if Twilio is fully configured', () => {
+      config.twilio.accountSid = 'ACxxxxxxxxxxxxxxx';
+      config.twilio.authToken = 'authxxxxxxxxxxxxx';
+      config.twilio.phoneNumber = '+1234567890';
+      jest.isolateModules(() => { // This ensures the module re-evaluates with the new config
+        twilioService = require('../twilio');
+      });
+      expect(twilioService.isConfigured()).toBe(true);
+    });
+
+    it('should return false if Twilio configuration is incomplete', () => {
+      config.twilio.accountSid = ''; // Missing accountSid
+      jest.isolateModules(() => {
+        twilioService = require('../twilio');
+      });
+      expect(twilioService.isConfigured()).toBe(false);
+    });
+  });
+});

--- a/src/services/twilio.js
+++ b/src/services/twilio.js
@@ -1,0 +1,64 @@
+const twilio = require('twilio');
+const config =require('../config');
+const logger = require('../utils/logger');
+
+let client;
+
+try {
+  if (!config.twilio.accountSid || !config.twilio.authToken || !config.twilio.phoneNumber) {
+    logger.warn('Twilio credentials not fully configured. SMS functionality will be disabled.');
+    client = null; // Explicitly set client to null if not configured
+  } else {
+    client = twilio(config.twilio.accountSid, config.twilio.authToken);
+    logger.info('Twilio client initialized successfully.');
+  }
+} catch (error) {
+  logger.error('Error initializing Twilio client:', error);
+  client = null; // Ensure client is null on error
+}
+
+/**
+ * Sends a text message using the Twilio API.
+ *
+ * @param {string} to The recipient's phone number. Must be in E.164 format.
+ * @param {string} body The content of the text message.
+ * @returns {Promise<object>} A promise that resolves with the Twilio message object on success.
+ * @throws {Error} If Twilio is not configured or if the message fails to send.
+ */
+async function sendTextMessage(to, body) {
+  if (!client) {
+    logger.error('Twilio client is not initialized. Cannot send SMS.');
+    throw new Error('Twilio service is not configured. Please check your environment variables.');
+  }
+
+  if (!to || !body) {
+    throw new Error('Recipient phone number (to) and message body are required.');
+  }
+
+  // Basic E.164 format validation (starts with +, followed by digits)
+  // For more robust validation, consider using a library like libphonenumber-js
+  if (!/^\+[1-9]\d{1,14}$/.test(to)) {
+    logger.warn(`Invalid phone number format: ${to}. Attempting to send anyway.`);
+    // Depending on requirements, you might want to throw an error here instead.
+  }
+
+  try {
+    const message = await client.messages.create({
+      body: body,
+      from: config.twilio.phoneNumber,
+      to: to,
+    });
+    logger.info(`SMS sent successfully to ${to}. Message SID: ${message.sid}`);
+    return message;
+  } catch (error) {
+    logger.error(`Error sending SMS to ${to}:`, error);
+    // Rethrow a more generic error or handle specific Twilio errors
+    throw new Error(`Failed to send SMS via Twilio: ${error.message}`);
+  }
+}
+
+module.exports = {
+  sendTextMessage,
+  // You can add a function here to check if Twilio is configured if needed elsewhere
+  isConfigured: () => !!client
+};


### PR DESCRIPTION
This commit introduces a new slash command `/send_text` that allows you to send SMS messages to a specified phone number using Twilio.

Changes include:
-   **Configuration:**
    -   Added Twilio credentials (Account SID, Auth Token, Phone Number) to `.env.example`.
    -   Updated `src/config/index.js` to load and expose these credentials.
-   **Twilio SDK:**
    -   Added `twilio` NPM package as a dependency.
-   **Twilio Service (`src/services/twilio.js`):**
    -   Initializes the Twilio client using credentials from the configuration.
    -   Provides a `sendTextMessage(to, body)` function to send SMS.
    -   Includes an `isConfigured()` helper to check Twilio setup.
-   **New Command (`src/commands/send_text.js`):**
    -   Defines the `/send_text` slash command with `phone_number` and `message` options.
    -   Validates phone number format (E.164).
    -   Uses the Twilio service to send the message.
    -   Provides feedback to you on success or failure.
    -   Checks if Twilio is configured before attempting to send.
-   **Command Handling:**
    -   The existing `commandHandler.js` will automatically load the new command.
    -   The `start.js` script handles command synchronization with Discord.
-   **Unit Tests:**
    -   Added Jest tests for `src/services/twilio.js` (mocking the Twilio client).
    -   Added Jest tests for `src/commands/send_text.js` (mocking interactions and the Twilio service).

To use this feature:
1.  Set the `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` environment variables.
2.  Run `npm install` (if not already done).
3.  Start/restart the bot (e.g., using `node start.js`).
4.  Use the `/send_text` command in Discord.